### PR TITLE
Fix compilation of the FMX package with Delphis older than XE5

### DIFF
--- a/source/component/ocv.comp.ViewFMX.pas
+++ b/source/component/ocv.comp.ViewFMX.pas
@@ -193,7 +193,9 @@ begin
     if Assigned(OnBeforePaint) then
       OnBeforePaint(Self, FImage);
 
+{$IFDEF DELPHIXE5_UP}
     IPLImageToFMXBitmap(FImage.IpImage, BackBuffer);
+{$IFEND}
     Canvas.DrawBitmap(BackBuffer, RectF(0, 0, BackBuffer.Width, BackBuffer.Height), PaintRect, 1, True);
 
     if Assigned(OnAfterPaint) then

--- a/source/ocv.fmxutils.pas
+++ b/source/ocv.fmxutils.pas
@@ -3,15 +3,21 @@ unit ocv.fmxutils;
 interface
 
 Uses
-  ocv.core.types_c,
-  FMX.Graphics;
+  ocv.core.types_c
+{$IFDEF DELPHIXE5_UP}
+  , FMX.Graphics
+{$IFEND}
+  ;
 
+{$IFDEF DELPHIXE5_UP}
 procedure IPLImageToFMXBitmap(const IpImage: pIplImage; const FMXBitmap: TBitmap); inline;
+{$IFEND}
 
 implementation
 
 Uses FMX.Types;
 
+{$IFDEF DELPHIXE5_UP}
 procedure IPLImageToFMXBitmap(const IpImage: pIplImage; const FMXBitmap: TBitmap); inline;
 Var
   BitmapData: TBitmapData;
@@ -56,5 +62,6 @@ begin
         FreeMem(SrcData);
     end;
 end;
+{$IFEND}
 
 end.


### PR DESCRIPTION
* The Unit FMX.Graphics is only available from XE5